### PR TITLE
Workaround for broken Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.12</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>vrealize-automation-8</artifactId>
@@ -84,9 +85,15 @@
             <version>2.1.4</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>snakeyaml-api</artifactId>
+            <version>1.27.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.threeten</groupId>

--- a/src/main/java/com/vmware/vra/jenkinsplugin/pipeline/WaitForAddressExecution.java
+++ b/src/main/java/com/vmware/vra/jenkinsplugin/pipeline/WaitForAddressExecution.java
@@ -43,6 +43,6 @@ public class WaitForAddressExecution extends SynchronousNonBlockingStepExecution
   protected List<String> run() throws Exception {
     final VraApi client = step.getClient();
     return client.waitForIPAddresses(
-        step.getDeploymentId(), step.getResourceName(), step.getTimeout() * 1000);
+        step.resolveDeploymentId(), step.getResourceName(), step.getTimeout() * 1000);
   }
 }

--- a/src/main/java/com/vmware/vra/jenkinsplugin/vra/VraApi.java
+++ b/src/main/java/com/vmware/vra/jenkinsplugin/vra/VraApi.java
@@ -155,7 +155,6 @@ public class VraApi implements Serializable {
           if (dep == null) {
             throw new IllegalArgumentException("Deployment doesn't exist: " + deploymentId);
           }
-          final List<Resource> resources = dep.getResources();
           final List<String> result = new ArrayList<>(dep.getResources().size());
           boolean missingAddress = false;
           boolean missingResource = true;


### PR DESCRIPTION
Recent versions of Jenkins pull in a broken/incompatible version of Jackson that breaks snakeyaml giving error messages similar to this:

```hudson.remoting.ProxyException: Can't construct a java object for tag:yaml.org,2002:com.vmware.vra.jenkinsplugin.pipeline.DeployFromCatalogExecution$Config; exception=Class not found: com.vmware.vra.jenkinsplugin.pipeline.DeployFromCatalogExecution$Config```

Working around this by loading yaml to a Map instead of a bean.